### PR TITLE
feat: sync latest version SDK OneID, bugfix rpc.tomochain.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 .env
 
 yarn.lock
+pnpm-lock.yaml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneid-xyz/connect-snap",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "module": "dist/bundle.js",
   "exports": {
     ".": {
@@ -16,7 +16,8 @@
   "license": "ISC",
   "dependencies": {
     "@metamask/snaps-sdk": "6.4.0",
-    "@oneid-xyz/inspect": "*"
+    "@oneid-xyz/inspect": "1.1.1",
+    "@oneid-xyz/base": "1.1.1"
   },
   "devDependencies": {
     "@metamask/snaps-cli": "6.3.2",

--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -2,8 +2,12 @@
   "version": "1.0.0",
   "description": "OneID using on metamask to resolve domain name",
   "proposedName": "OneID",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/coin98/connect-snap.git"
+  },
   "source": {
-    "shasum": "gmYE8TVMpmyXQnZmskdiIb6q23TMKqBqyFKPGebYI2g=",
+    "shasum": "2bwzPcBw5MjepC/kogw754aEFKjwLT0LUEBxLz7ODfw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -18,13 +22,10 @@
   },
   "initialPermissions": {
     "endowment:name-lookup": {
-      "chains": [
-        "eip155:88",
-        "eip155:1",
-        "eip155:56"
-      ]
+      "chains": ["eip155:88", "eip155:1", "eip155:56"]
     },
     "endowment:network-access": {}
   },
+  "platformVersion": "6.4.0",
   "manifestVersion": "0.1"
 }


### PR DESCRIPTION
- Sync
> - @oneid-xyz/inspect": "1.1.1
> - @oneid-xyz/base": "1.1.1